### PR TITLE
Updated and fixed wrong SHS links in readmes and metadata files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![Latest Release](https://img.shields.io/github/v/release/SpellholdStudios/ImoenFriendship?include_prereleases&color=darkred)<a name="top" id="top">
+![Latest Release](https://img.shields.io/github/v/release/SpellholdStudios/ImoenFriendship?include_prereleases&color=darkred)<a name="top" id="top"> </a>
 ![Platform](https://img.shields.io/static/v1?label=platform&message=windows%20%7C%20macos%20%7C%20linux&color=informational)
 ![Language](https://img.shields.io/static/v1?label=language&message=English%20%7C%20French%20%7C%20Polish%20%7C%20Russian%20%7C%20Spanish%20%7C%20Chinese&color=limegreen)
 
@@ -12,7 +12,7 @@ Baldur's Gate Trilogy and EET<h3>
 
 **Author:** K'aeloree  
 **Mod Website:** <a href="http://www.spellholdstudios.net/ie/npciep">Spellhold Studios</a>  
-**Mod Forum:** <a href="http://www.shsforums.net/index.php?showforum=574">Imoen Friendship</a><br /><br />
+**Mod Forum:** <a href="http://www.shsforums.net/forum/599-imoen-friendship/">Imoen Friendship</a><br /><br />
 
 
 <div align="center">
@@ -30,7 +30,7 @@ One of the things many find sorely lacking in the Bioware NPCs are the more comp
 This mod adds a series of dialogues with Imoen, the PC's sister, expanding on Imoen's experiences and struggles.
 
 
-Visit the <a href="http://www.spellholdstudios.net/ie/npciep">website</a> or <a href="http://www.shsforums.net/index.php?showforum=574">forum</a> for all the latest updates.
+Visit the <a href="http://www.spellholdstudios.net/ie/npciep">website</a> or <a href="http://www.shsforums.net/forum/599-imoen-friendship/">forum</a> for all the latest updates.
 
 
 <hr>
@@ -155,6 +155,13 @@ A: Sure, we'd be happy to. If you are interested in translating, just send us a 
 
 
 ## <a name="versions" id="versions"></a>Versions History
+
+##### Version 3.5 (December 14, 2019)
+
+- Fixed an issue with *Auto-Package Generator tool*: new version of MacOS (Catalina) prevented the mod to be installed.
+- Fixed wrong SHS links in readmes and metadata files.
+
+## 
 
 ##### Version 3.4 (November 24, 2019)
 

--- a/imoenfriendship/imoenfriendship-readme-english.html
+++ b/imoenfriendship/imoenfriendship-readme-english.html
@@ -313,8 +313,8 @@
         <p class="about">
 
           <a href="http://www.spellholdstudios.net/ie/npciep">Mod Website</a> &#8226;
-          <a href="http://www.shsforums.net/index.php?showforum=574">Mod Forum</a> &#8226;
-          Version: 3.4
+          <a href="http://www.shsforums.net/forum/599-imoen-friendship/">Mod Forum</a> &#8226;
+          Version: 3.5
         </p>
         <hr />
         <p class="menu">
@@ -337,7 +337,7 @@
 
           <p>This mod adds a series of dialogues with Imoen, the PC's sister, expanding on Imoen's experiences and struggles.</p>
 
-          <p>Visit the <a href="http://www.spellholdstudios.net/ie/npciep">website</a> or <a href="http://www.shsforums.net/index.php?showforum=574">forum</a> for all the latest updates.</p><br>
+          <p>Visit the <a href="http://www.spellholdstudios.net/ie/npciep">website</a> or <a href="http://www.shsforums.net/forum/599-imoen-friendship/">forum</a> for all the latest updates.</p><br>
 
           <address>
             <span class="footer">Imoen Friendship &gt; Introduction</span> &#8226;<a href="#top">BACK TO TOP</a>
@@ -357,7 +357,7 @@
 
           <h5>Compatibility and Installation Order</h5>
 
-          <p>The Imoen Friendship mod should be compatible with all WeiDU mods, however, we cannot test every single one. It is only compatible with BGII: ToB. If you do encounter an error, please contact <a href="kae@spellholdstudios.net">K'aeloree</a> or alternatively post on the <a href="http://www.shsforums.net/index.php?showforum=574">forums</a>.</p>
+          <p>The Imoen Friendship mod should be compatible with all WeiDU mods, however, we cannot test every single one. It is only compatible with BGII: ToB. If you do encounter an error, please contact <a href="kae@spellholdstudios.net">K'aeloree</a> or alternatively post on the <a href="http://www.shsforums.net/forum/599-imoen-friendship/">forums</a>.</p>
           <p>Although it is not required for the Imoen Friendship to function properly, it is always a good idea install the latest version of the <a href="http://www.gibberlings3.net/bg2fixpack/">BG2 Fixpack</a>.</p><br>
  
           <address>
@@ -431,6 +431,13 @@
 
         <div class="content">
           <h2>Version history</h2><br>
+
+		<h6>Version 3.5 (December 14, 2019)</h6>
+
+		  <ul>
+			<li>Fixed an issue with <em>Auto-Package Generator tool</em>: new version of MacOS (Catalina) prevented the mod to be installed.</li>
+			<li>Fixed wrong SHS links in readmes and metadata files.</li>
+		  </ul><br>
 
          <h6>Version 3.4 (November 24, 2019)</h6>
           <ul>

--- a/imoenfriendship/imoenfriendship-readme-french.html
+++ b/imoenfriendship/imoenfriendship-readme-french.html
@@ -313,8 +313,8 @@
         <p class="about">
 
           <a href="http://www.spellholdstudios.net/ie/npciep">Site du mod</a> &#8226;
-          <a href="http://www.shsforums.net/index.php?showforum=574">Forum du mod</a> &#8226;
-          Version: 3.4
+          <a href="http://www.shsforums.net/forum/599-imoen-friendship/">Forum du mod</a> &#8226;
+          Version: 3.5
         </p>
         <hr />
         <p class="menu">
@@ -337,7 +337,7 @@
 
           <p>Ce mod ajoute une série de dialogues avec Imoen, la sœur du PJ, développant son vécu et les luttes d'Imoen.</p>
 
-          <p>Visitez le <a href="http://www.spellholdstudios.net/ie/npciep">site web</a> ou le <a href="http://www.shsforums.net/index.php?showforum=574">forum</a> pour les dernières mises à jour.</p><br>
+          <p>Visitez le <a href="http://www.spellholdstudios.net/ie/npciep">site web</a> ou le <a href="http://www.shsforums.net/forum/599-imoen-friendship/">forum</a> pour les dernières mises à jour.</p><br>
 
           <address>
           <address>
@@ -358,7 +358,7 @@
 
           <h5>Compatibilité et ordre d'installation</h5>
 
-          <p>Le mod Imoen Friendship devrait être compatible avec n'importe quel mod WeiDU, nous ne pouvons cependant pas tous les tester. Il n'est compatible qu'avec BGII : ToB. Si vous rencontrez une erreur, veuillez contactez <a href="kae@spellholdstudios.net">K'aeloree</a> ou bien postez dans les <a href="http://www.shsforums.net/index.php?showforum=574">forums</a>.</p>
+          <p>Le mod Imoen Friendship devrait être compatible avec n'importe quel mod WeiDU, nous ne pouvons cependant pas tous les tester. Il n'est compatible qu'avec BGII : ToB. Si vous rencontrez une erreur, veuillez contactez <a href="kae@spellholdstudios.net">K'aeloree</a> ou bien postez dans les <a href="http://www.shsforums.net/forum/599-imoen-friendship/">forums</a>.</p>
           <p>Bien qu'il ne soit pas requis pour faire correctement tourner Imoen Friendship, il est toujours utile d'avoir installé la dernière version du <a href="http://www.gibberlings3.net/bg2fixpack/">BG2 Fixpack</a>.</p><br>
 
           <address>
@@ -397,7 +397,7 @@
 
           <h5>Remerciements :</h5><br>
           <ul>
-            <li>Traduction française: Isaya es Les d'Oghmatiques.</li>
+            <li>Traduction française: Isaya et Les d'Oghmatiques.</li>
             <li>Traduction polonaise : Lava Del'Vortel.</li>
             <li>Traduction russe : ArcaneCoast.ru, thanks to prowler and Ardanis_gen1e.</li>
             <li>Traduction espagnole : Clan DLAN.</li>
@@ -432,6 +432,13 @@
 
         <div class="content">
           <h2>Historique des versions</h2><br>
+
+		<h6>Version 3.5 (December 14, 2019)</h6>
+
+		  <ul>
+			<li>Fixed an issue with <em>Auto-Package Generator tool</em>: new version of MacOS (Catalina) prevented the mod to be installed.</li>
+			<li>Fixed wrong SHS links in readmes and metadata files.</li>
+		  </ul><br>
 
          <h6>Version 3.4 (November 24, 2019)</h6>
           <ul>

--- a/imoenfriendship/imoenfriendship.ini
+++ b/imoenfriendship/imoenfriendship.ini
@@ -18,10 +18,10 @@ Author = Kaeloree
 Description = One of the things many find sorely lacking in the Bioware NPCs are the more complex relationships presented by modern NPC mods--especially in regards to "friendships", the relationships NPCs have with the PC when not romancing them. This mod adds a series of dialogues with Imoen, the PC's sister, expanding on Imoen's experiences and struggles. (ToB, BGT, BGII:EE, EET).
 
 # Web address of mod readme file (filename is case-sensitive!)
-Readme = http://spellholdstudios.github.io/SpellholdStudios.github.io/readmes/imoenfriendship-readme-english.html, http://spellholdstudios.github.io/SpellholdStudios.github.io/readmes/imoenfriendship-readme-%LANGUAGE%.html, 
+Readme = http://spellholdstudios.github.io/readmes/imoenfriendship-readme-english.html, http://spellholdstudios.github.io/readmes/imoenfriendship-readme-%LANGUAGE%.html
 
 # Web address of mod dedicated forum or forum thread 
-Forum = http://www.shsforums.net/index.php?showforum=353
+Forum = http://www.shsforums.net/forum/599-imoen-friendship/
 
 # Web address of mod personal Homepage, no need to duplicate with mod dedicated forum
 Homepage = http://www.spellholdstudios.net/ie/imoenfriendship

--- a/imoenfriendship/imoenfriendship.tp2
+++ b/imoenfriendship/imoenfriendship.tp2
@@ -4,7 +4,7 @@
 // Basics
 BACKUP ~imoenfriendship/backup~
 AUTHOR ~K'aeloree (kae@spellholdstudios.net)~
-VERSION ~v3.4~
+VERSION ~v3.5~
 README ~imoenfriendship/imoenfriendship-readme-%LANGUAGE%.html~ ~imoenfriendship/imoenfriendship-readme-english.html~
 
 // Translations


### PR DESCRIPTION
- Fixed an issue with *Auto-Package Generator tool*: new version of MacOS (Catalina) prevented the mod to be installed.
- Fixed wrong link in *iepbanters.ini* metadata file.